### PR TITLE
chore(actions): replace deployment PAT with app dispatch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_TOKEN }}
+          password: ${{ github.token }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -51,37 +51,14 @@ jobs:
       name: prod
     if: ${{ github.event_name != 'pull_request' && ( github.ref == 'refs/heads/master' || github.ref == 'refs/heads/qa' ) }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Dispatch deployment
+        uses: devsoc-unsw/deployment-dispatch-action@main
         with:
-          repository: csesoc/deployment
-          token: ${{ secrets.GH_TOKEN }}
+          deployment-dispatcher-app-id: ${{ vars.DEPLOYMENT_DISPATCHER_APP_ID }}
+          deployment-dispatcher-app-private-key: ${{ secrets.DEPLOYMENT_DISPATCHER_APP_PRIVATE_KEY }}
+          owner: csesoc
+          repository: deployment
           ref: develop
-      - name: Install yq - portable yaml processor
-        uses: mikefarah/yq@v4.27.2
-      - name: "Determine deployment type"
-        id: get_manifest
-        env:
-          BRANCH: ${{ github.ref }}
-        run: |
-          if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
-            echo "TYPE=prod" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.ref }}" == "refs/heads/qa" ]]; then
-            echo "TYPE=qa" >> $GITHUB_OUTPUT
-          else
-            exit 1
-          fi
-      - name: Update deployment
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          git config user.name "CSESoc CD"
-          git config user.email "technical@csesoc.org.au"
-          git checkout -b update/website-${{ steps.get_manifest.outputs.TYPE }}/${{ github.sha }}
-          yq -i '.items[0].spec.template.spec.containers[0].image = "ghcr.io/csesoc/website-backend:${{ github.sha }}"' apps/projects/website/${{ steps.get_manifest.outputs.TYPE }}/deploy-backend.yml
-          yq -i '.items[0].spec.template.spec.containers[0].image = "ghcr.io/csesoc/website-frontend:${{ github.sha }}"' apps/projects/website/${{ steps.get_manifest.outputs.TYPE }}/deploy-frontend.yml
-          git add .
-          git commit -m "feat(website/${{ steps.get_manifest.outputs.TYPE }}): update image"
-          git push -u origin update/website-${{ steps.get_manifest.outputs.TYPE }}/${{ github.sha }}
-          gh pr create -B develop --title "feat(website/${{ steps.get_manifest.outputs.TYPE }}): update image" --body "Updates the image for the website-prod deployment to commit csesoc/csesoc-website@${{ github.sha }}." > URL
-          gh pr merge $(cat URL) --squash -d
+          updates: |
+            ghcr.io/csesoc/website-backend=${{ github.sha }}
+            ghcr.io/csesoc/website-frontend=${{ github.sha }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,9 @@ on:
       - "master"
       - "qa"
 
+env:
+  IMAGE_NAME: ${{ github.ref_name == 'master' && 'website' || 'website-qa' }}
+
 jobs:
   build:
     name: "Build (${{ matrix.component }})"
@@ -39,8 +42,8 @@ jobs:
           platforms: linux/amd64
           file: ${{ matrix.component }}/Dockerfile
           tags: |
-            ghcr.io/csesoc/website-${{ matrix.component }}:${{ github.sha }}
-            ghcr.io/csesoc/website-${{ matrix.component }}:latest
+            ghcr.io/csesoc/${{ env.IMAGE_NAME }}-${{ matrix.component }}:${{ github.sha }}
+            ghcr.io/csesoc/${{ env.IMAGE_NAME }}-${{ matrix.component }}:latest
           labels: ${{ steps.meta.outputs.labels }}
   deploy:
     name: Deploy (CD)
@@ -60,5 +63,5 @@ jobs:
           repository: deployment
           ref: develop
           updates: |
-            ghcr.io/csesoc/website-backend=${{ github.sha }}
-            ghcr.io/csesoc/website-frontend=${{ github.sha }}
+            ghcr.io/csesoc/${{ env.IMAGE_NAME }}-backend=${{ github.sha }}
+            ghcr.io/csesoc/${{ env.IMAGE_NAME }}-frontend=${{ github.sha }}


### PR DESCRIPTION
## Summary
Use the shared `deployment-dispatch-action` in `.github/workflows/docker.yml` instead of directly checking out and editing `csesoc/deployment` from this repo's workflow, while splitting qa from prod by publishing to distinct image names.

## Changes
- replace the current deploy step flow with `devsoc-unsw/deployment-dispatch-action@main`
- switch GHCR publish authentication to `github.token`
- keep `master` publishing `ghcr.io/csesoc/website-backend` and `ghcr.io/csesoc/website-frontend`
- make `qa` publish `ghcr.io/csesoc/website-qa-backend` and `ghcr.io/csesoc/website-qa-frontend`
- dispatch the branch-specific image names instead of shared image names
- use `vars.DEPLOYMENT_DISPATCHER_APP_ID` and `secrets.DEPLOYMENT_DISPATCHER_APP_PRIVATE_KEY`

## Dependencies
- `csesoc/deployment` PR: https://github.com/csesoc/deployment/pull/3873

## Verification
- `rg -n "IMAGE_NAME|website-qa-(backend|frontend)" .github/workflows/docker.yml`
- `actionlint -color .github/workflows/docker.yml` still reports the pre-existing missing `steps.meta` definition
